### PR TITLE
Address sqlalchemy warnings with conflicting relationships

### DIFF
--- a/gsshapyorm/orm/evt.py
+++ b/gsshapyorm/orm/evt.py
@@ -15,8 +15,8 @@ class ProjectFileEventManager(DeclarativeBase, GsshaPyFileObjectBase):
 
     id = Column(Integer, autoincrement=True, primary_key=True)  #: PK
     project_file_id = Column(Integer, ForeignKey('prj_project_files.id'))
-    projectFile = relationship('ProjectFile')
     fileExtension = Column(String, default='yml')
+    projectFile = relationship('ProjectFile', back_populates='projectFileEventManager')
     events = relationship('ProjectFileEvent',
                           lazy='dynamic',
                           cascade="save-update,merge,delete,delete-orphan")  #: RELATIONSHIP

--- a/gsshapyorm/orm/prj.py
+++ b/gsshapyorm/orm/prj.py
@@ -111,7 +111,8 @@ class ProjectFile(DeclarativeBase, GsshaPyFileObjectBase):
     linkNodeDatasets = relationship('LinkNodeDatasetFile', back_populates='projectFile')  #: RELATIONSHIP
     genericFiles = relationship('GenericFile', back_populates='projectFile')  #: RELATIONSHIP
     wmsDatasets = relationship('WMSDatasetFile', back_populates='projectFile')  #: RELATIONSHIP
-    projectFileEventManager = relationship('ProjectFileEventManager', uselist=False)  #: RELATIONSHIP
+    projectFileEventManager = relationship('ProjectFileEventManager', back_populates='projectFile',
+                                           uselist=False)  #: RELATIONSHIP
 
     # File Properties
     MAP_TYPES_SUPPORTED = (1,)


### PR DESCRIPTION
- Add `back_populates` to the project event relationships