### PR TITLE
Always rename projection files to match the new project name

### DIFF
--- a/gsshapyorm/orm/prj.py
+++ b/gsshapyorm/orm/prj.py
@@ -1888,8 +1888,8 @@ class ProjectFile(DeclarativeBase, GsshaPyFileObjectBase):
             # stay the same
             filename = originalFilename
 
-        elif originalPrefix == originalProjectName and pro:
-            # Handle renaming of projection file
+        elif pro:
+            # Always rename projection files to match the new project name
             filename = '%s_prj.%s' % (name, extension)
 
         elif originalPrefix == originalProjectName:


### PR DESCRIPTION
This pull request updates the logic for renaming projection files in the `_replaceNewFilename` method in `gsshapyorm/orm/prj.py`. The change ensures that projection files are always renamed to match the new project name, regardless of the original prefix.

File renaming logic:

* Modified `_replaceNewFilename` to always rename projection files to match the new project name, improving consistency in file naming.