### PR TITLE
Update to include permafrost keyword in cmt.

### DIFF
--- a/gsshapyorm/lib/cmt_chunk.py
+++ b/gsshapyorm/lib/cmt_chunk.py
@@ -276,6 +276,75 @@ def _buildVarList(sline, mapTableName, numVars):
     return varList
 
 
+def permafrostChunk(key, chunk):
+    """
+    Parse PERMAFROST_LAYER_SOIL mapping table chunk.
+
+    This table has special parameters like MAX_NUMBER_LAYERS, DN_INIT_MAX, DN_MAX,
+    and file references for INIT_TEMP_FILE, DEP_NODE_FILE, OUT_NODE_FILE.
+    """
+    # Global variables
+    numVars = {'NUM_IDS': None,
+               'MAX_NUMBER_CELLS': None,
+               'NUM_SED': None,
+               'NUM_CONTAM': None,
+               'MAX_SOIL_ID': None}
+    permafrostVars = {'MAX_NUMBER_LAYERS': None,
+                      'DN_INIT_MAX': None,
+                      'DN_MAX': None,
+                      'INIT_TEMP_FILE': None,
+                      'DEP_NODE_FILE': None,
+                      'OUT_NODE_FILE': None}
+    varList = []
+    valueList = []
+
+    # Extract MapTable Name and Index Map Name
+    mtName = shlex.split(chunk[0])[0]
+    idxName = shlex.split(chunk[0])[1] if len(shlex.split(chunk[0])) > 1 else ''
+
+    # Check if the table is empty (NUM_IDS = 0)
+    # If empty, we still need to process it but not read value lines
+    num_ids = None
+
+    # Parse the chunk into a datastructure
+    for line in chunk:
+        sline = line.strip().split()
+        if not sline:
+            continue
+        token = sline[0]
+
+        if token == key:
+            # Already extracted above
+            pass
+        elif token in numVars:
+            # Extract NUM type variables
+            numVars[token] = sline[1]
+            if token == 'NUM_IDS':
+                num_ids = int(sline[1])
+        elif token in permafrostVars:
+            # Extract permafrost-specific variables
+            permafrostVars[token] = sline[1]
+        elif token == 'ID':
+            # Extract variable names from header line
+            varList = _buildVarList(sline=sline, mapTableName=mtName, numVars=numVars)
+        else:
+            # Only extract value lines if NUM_IDS > 0
+            if num_ids is not None and num_ids > 0:
+                valDict = _extractValues(line)
+                valueList.append(valDict)
+
+    # Create return/result object
+    result = {'name': mtName,
+              'indexMapName': idxName,
+              'numVars': numVars,
+              'permafrostVars': permafrostVars,
+              'varList': varList,
+              'valueList': valueList,
+              'contaminants': None}
+
+    return result
+
+
 def _extractValues(line):
     valDict = dict()
     # Extract value line via slices

--- a/gsshapyorm/orm/cmt.py
+++ b/gsshapyorm/orm/cmt.py
@@ -13,7 +13,8 @@ __all__ = ['MapTableFile',
            'MTValue',
            'MTIndex',
            'MTContaminant',
-           'MTSediment']
+           'MTSediment',
+           'MTPermafrost']
 
 from io import open as io_open
 import os
@@ -109,7 +110,8 @@ class MapTableFile(DeclarativeBase, GsshaPyFileObjectBase):
                     'MULTI_LAYER_SOIL': mtc.mapTableChunk,
                     'SOIL_EROSION_PROPS': mtc.mapTableChunk,
                     'CONTAMINANT_TRANSPORT': mtc.contamChunk,
-                    'SEDIMENTS': mtc.sedimentChunk}
+                    'SEDIMENTS': mtc.sedimentChunk,
+                    'PERMAFROST_LAYER_SOIL': mtc.permafrostChunk}
 
         indexMaps = dict()
         mapTables = []
@@ -197,6 +199,11 @@ class MapTableFile(DeclarativeBase, GsshaPyFileObjectBase):
                                             mapTable=mapTable,
                                             contaminants=contaminants,
                                             replaceParamFile=replaceParamFile)
+            elif mapTable.name == 'PERMAFROST_LAYER_SOIL':
+                self._writePermafrostTable(session=session,
+                                           fileObject=openFile,
+                                           mapTable=mapTable,
+                                           replaceParamFile=replaceParamFile)
             elif mapTable.name == 'TIME_SERIES_INDEX':
                 self._writeTimeSeriesIndex(session=session,
                                            fileObject=openFile,
@@ -292,6 +299,29 @@ class MapTableFile(DeclarativeBase, GsshaPyFileObjectBase):
 
                         # Associate the MTSediment with the MapTable
                         sediment.mapTable = mapTable
+
+                # PERMAFROST_LAYER_SOIL map table handler
+                elif mt['name'] == 'PERMAFROST_LAYER_SOIL':
+                    # Create GSSHAPY MTPermafrost object with special parameters
+                    pf_vars = mt['permafrostVars']
+                    permafrost = MTPermafrost(
+                        maxNumberLayers=int(pf_vars['MAX_NUMBER_LAYERS']) if pf_vars['MAX_NUMBER_LAYERS'] else None,
+                        dnInitMax=int(pf_vars['DN_INIT_MAX']) if pf_vars['DN_INIT_MAX'] else None,
+                        dnMax=int(pf_vars['DN_MAX']) if pf_vars['DN_MAX'] else None,
+                        initTempFile=pf_vars['INIT_TEMP_FILE'],
+                        depNodeFile=pf_vars['DEP_NODE_FILE'],
+                        outNodeFile=pf_vars['OUT_NODE_FILE']
+                    )
+
+                    # Associate the MTPermafrost with the MapTable
+                    permafrost.mapTable = mapTable
+
+                    # Create MTValue and MTIndex objects if there are values
+                    if mt['indexMapName'] and mt['indexMapName'] in indexMaps:
+                        indexMap = indexMaps[mt['indexMapName']]
+                        mapTable.indexMap = indexMap
+                        self._createValueObjects(mt['valueList'], mt['varList'], mapTable, indexMap,
+                                                 None, replaceParamFile)
 
                 elif mt['name'] == 'TIME_SERIES_INDEX':
                     for line in mt['valueList']:
@@ -499,6 +529,37 @@ class MapTableFile(DeclarativeBase, GsshaPyFileObjectBase):
         for ts in time_series_indices:
             spaces = 6 - len(ts.index)
             fileObject.write(f'{ts.index}{" " * spaces}{ts.time_series_name}\n')
+
+    def _writePermafrostTable(self, session, fileObject, mapTable, replaceParamFile):
+        """
+        Write Permafrost Layer Soil Mapping Table Method
+
+        This method writes the PERMAFROST_LAYER_SOIL special mapping table case.
+        """
+        # Get the permafrost parameters
+        permafrost = mapTable.permafrost
+
+        # Write the permafrost mapping table header
+        fileObject.write('%s "%s"\n' % (mapTable.name, mapTable.indexMap.name if mapTable.indexMap else ''))
+        fileObject.write('NUM_IDS %s\n' % (mapTable.numIDs))
+
+        # Write permafrost-specific parameters
+        if permafrost:
+            if permafrost.maxNumberLayers is not None:
+                fileObject.write('MAX_NUMBER_LAYERS %s\n' % permafrost.maxNumberLayers)
+            if permafrost.dnInitMax is not None:
+                fileObject.write('DN_INIT_MAX %s\n' % permafrost.dnInitMax)
+            if permafrost.dnMax is not None:
+                fileObject.write('DN_MAX %s\n' % permafrost.dnMax)
+            if permafrost.initTempFile:
+                fileObject.write('INIT_TEMP_FILE %s\n' % permafrost.initTempFile)
+            if permafrost.depNodeFile:
+                fileObject.write('DEP_NODE_FILE %s\n' % permafrost.depNodeFile)
+            if permafrost.outNodeFile:
+                fileObject.write('OUT_NODE_FILE %s\n' % permafrost.outNodeFile)
+
+        # Write value lines
+        self._writeValues(session, fileObject, mapTable, None, replaceParamFile)
 
     def _valuePivot(self, session, mapTable, contaminant, replaceParaFile):
         """
@@ -806,6 +867,8 @@ class MapTable(DeclarativeBase):
                              cascade='all, delete, delete-orphan')  #: RELATIONSHIP
     time_series_indices = relationship('MTTimeSeriesIndex', back_populates='mapTable',
                                        cascade='all, delete, delete-orphan')  #: RELATIONSHIP
+    permafrost = relationship('MTPermafrost', back_populates='mapTable', uselist=False,
+                              cascade='all, delete, delete-orphan')  #: RELATIONSHIP
 
     def __init__(self, name, numIDs=None, maxNumCells=None, numSed=None, numContam=None, maxSoilID=None):
         """
@@ -1049,3 +1112,60 @@ class MTTimeSeriesIndex(DeclarativeBase):
     def __eq__(self, other):
         return (self.index == other.index and
                 self.time_series_name == other.time_series_name)
+
+
+class MTPermafrost(DeclarativeBase):
+    """
+    Object containing data in permafrost layer soil type mapping tables.
+
+    This special mapping table has additional parameters for permafrost modeling:
+    - MAX_NUMBER_LAYERS: Maximum number of soil layers
+    - DN_INIT_MAX: Maximum initial depth node
+    - DN_MAX: Maximum depth node
+    - INIT_TEMP_FILE: Initial temperature file
+    - DEP_NODE_FILE: Depth node file
+    - OUT_NODE_FILE: Output node file
+    """
+    __tablename__ = 'cmt_permafrost'
+
+    tableName = __tablename__  #: Database tablename
+
+    # Primary and Foreign Keys
+    id = Column(Integer, autoincrement=True, primary_key=True)  #: PK
+    mapTableID = Column(Integer, ForeignKey('cmt_map_tables.id'))  #: FK
+
+    # Value Columns
+    maxNumberLayers = Column(Integer)  #: INTEGER
+    dnInitMax = Column(Integer)  #: INTEGER
+    dnMax = Column(Integer)  #: INTEGER
+    initTempFile = Column(String)  #: STRING
+    depNodeFile = Column(String)  #: STRING
+    outNodeFile = Column(String)  #: STRING
+
+    # Relationship Properties
+    mapTable = relationship('MapTable', back_populates='permafrost', uselist=False)  #: RELATIONSHIP
+
+    def __init__(self, maxNumberLayers=None, dnInitMax=None, dnMax=None,
+                 initTempFile=None, depNodeFile=None, outNodeFile=None):
+        """
+        Constructor
+        """
+        self.maxNumberLayers = maxNumberLayers
+        self.dnInitMax = dnInitMax
+        self.dnMax = dnMax
+        self.initTempFile = initTempFile
+        self.depNodeFile = depNodeFile
+        self.outNodeFile = outNodeFile
+
+    def __repr__(self):
+        return f'<MTPermafrost: MaxLayers={self.maxNumberLayers}, DnInitMax={self.dnInitMax}, ' \
+               f'DnMax={self.dnMax}, InitTempFile={self.initTempFile}, ' \
+               f'DepNodeFile={self.depNodeFile}, OutNodeFile={self.outNodeFile}>'
+
+    def __eq__(self, other):
+        return (self.maxNumberLayers == other.maxNumberLayers and
+                self.dnInitMax == other.dnInitMax and
+                self.dnMax == other.dnMax and
+                self.initTempFile == other.initTempFile and
+                self.depNodeFile == other.depNodeFile and
+                self.outNodeFile == other.outNodeFile)

--- a/gsshapyorm/orm/prj.py
+++ b/gsshapyorm/orm/prj.py
@@ -1286,7 +1286,7 @@ class ProjectFile(DeclarativeBase, GsshaPyFileObjectBase):
         osr_geographic_proj = osgeo.osr.SpatialReference()
         osr_geographic_proj.ImportFromEPSG(4326)
         proj_transform = osgeo.osr.CoordinateTransformation(source_lyr_proj,
-                                                      osr_geographic_proj)
+                                                            osr_geographic_proj)
         boundary_feature = source_layer.GetFeature(0)
         feat_geom = boundary_feature.GetGeometryRef()
         feat_geom.Transform(proj_transform)

--- a/gsshapyorm/orm/wms_dataset.py
+++ b/gsshapyorm/orm/wms_dataset.py
@@ -503,12 +503,12 @@ class WMSDatasetFile(DeclarativeBase, GsshaPyFileObjectBase):
                   f'The number of rows in the raster ({len(cellArray)}) '
                   f'does not match number of rows expected ({irows}).')
             return False
-        
+
         elif any([len(row) != icolumns for row in cellArray]):
             bad_count = None
             for row in cellArray:
                 if len(row) != icolumns:
-                    bad_count = len(row) 
+                    bad_count = len(row)
                     break
             print(f'WARNING: The raster for timestep {timeStep} from WMS Dataset "{filename}" is invalid. '
                   f'The number of columns in at least one of the rows in the raster ({bad_count}) '


### PR DESCRIPTION
Add PERMAFROST_LAYER_SOIL keyword to the CMT mapping table file, to handle reading and writing permafrost mapping tables.

Missing table names in a CMT mapping file cause issues writing to the tables.